### PR TITLE
Fix go build so the binary runs in alpine container

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,11 @@ name: default
 
 steps:
 - name: build
-  image: golang
+  image: golang:1.12
+  environment:
+    GOOS: linux
+    GARCH: amd64
+    CGO_ENABLED: "0"
   commands:
   - go build
   - go test ./...


### PR DESCRIPTION
Currently the docker image does not function at all:

```
$ docker run drone/drone-admit-members
standard_init_linux.go:211: exec user process caused "no such file or directory"
```

This is because the binary inside is not compiled for alpine:

```
$ docker run --entrypoint="/bin/sh" -it drone/drone-admit-members
/ # ls /bin/drone-admit-members
/bin/drone-admit-members
/ # /bin/drone-admit-members
/bin/sh: /bin/drone-admit-members: not found
/ # ldd /bin/drone-admit-members
	/lib64/ld-linux-x86-64.so.2 (0x7f373dffe000)
	libpthread.so.0 => /lib64/ld-linux-x86-64.so.2 (0x7f373dffe000)
	libc.so.6 => /lib64/ld-linux-x86-64.so.2 (0x7f373dffe000)
```

So here I am:

- Adding required env vars to build a binary to run in the alpine docker image
- Fixing `build` step to use `golang:1.12` since this version is in `go.mod`
