### PR TITLE
Add drone access based on team membership (optional)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ An admission extension to limit system access based on GitHub organization and t
 * if user is organization member, grant access
 * if user is organization admin, grant admin access
 * if user is member of designated team, grant admin access (optional)
+* if user is member of designated team, grant access to drone (optional)
 
 ## Installation
 
@@ -25,6 +26,7 @@ $ docker run -d \
   --env=DRONE_GITHUB_TOKEN=3da541559918a808c2402bba5012f6c6 \
   --env=DRONE_GITHUB_ORG=acme \
   --env=DRONE_GITHUB_TEAM=admins \
+  --env=DRONE_GITHUB_TEAM_ACESS=drone-team \
   --restart=always \
   --name=admitter drone/drone-admit-members
 ```


### PR DESCRIPTION
My organization had the need to allow access to drone to only members of a given GitHub team within the organization. I thus thought this might be something of interest for others and decided to open this PR to implement an optional flag to give access to only members of a given GitHub team. 