### PR TITLE
support comma-separated list of orgs and teams

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:3.6 as alpine
+FROM alpine:3.15 as alpine
 RUN apk add -U --no-cache ca-certificates
 
-FROM alpine:3.6
+FROM alpine:3.15
 EXPOSE 3000
 
 ENV GODEBUG netdns=go


### PR DESCRIPTION
Doc is saying `DRONE_GITHUB_ORG` and `DRONE_GITHUB_TEAM` support Comma-separated lists but code doesn't.
-> https://docs.drone.io/server/extensions/github/

Changes are backward compatible and no upgrade actions are required.

image for testing: `maciekm/drone-admit-members`